### PR TITLE
Fix missing dependency on map library

### DIFF
--- a/corfu-doc.el
+++ b/corfu-doc.el
@@ -36,6 +36,7 @@
   (require 'cl-lib)
   (require 'subr-x))
 (require 'corfu)
+(require 'map)
 
 (defgroup corfu-doc nil
   "Display documentation popup alongside corfu."


### PR DESCRIPTION
There's a dependency on the map library for the `map-merge` function.

## Reproducing error

Remove your `build/` folder (for me, since I'm using straight.el, it's at `~/.emacs.d/straight/build/`) or rename it. Load the following file like `emacs -Q -l debug.el`

``` emacs-lisp
;; Setup package manager
(defvar bootstrap-version)
(setq straight-repository-branch "develop")

(let ((bootstrap-file
       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
      (bootstrap-version 5))
  (unless (file-exists-p bootstrap-file)
    (with-current-buffer
        (url-retrieve-synchronously
         "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
         'silent 'inhibit-cookies)
      (goto-char (point-max))
      (eval-print-last-sexp)))
  (load bootstrap-file nil 'nomessage))

(straight-use-package 'use-package)
(setq straight-use-package-by-default t)

(use-package corfu
  :config
  (corfu-global-mode)
  (setq tab-always-indent 'complete)
  (setq corfu-max-width 150))

(use-package corfu-doc
  :after corfu
  :straight (corfu-doc :type git :host github :repo "galeo/corfu-doc")
  :hook (corfu-mode . corfu-doc-mode)
  :bind (:map corfu-map
              ("M-j" . 'corfu-doc-scroll-down)
              ("M-k" . 'corfu-doc-scroll-up)))
```

You should get a compile error about a missing definition.

This bug was a little hard to spot, because if a package already loaded the `map` library, Emacs wouldn't complain.