### PR TITLE
Don't update doc frame immediately if it is visible, use idle timer

### DIFF
--- a/corfu-doc.el
+++ b/corfu-doc.el
@@ -331,9 +331,12 @@ If this is nil, do not resize corfu doc frame automatically."
 (defun corfu-doc--set-timer (&rest _args)
   (when (or (null corfu-doc--timer)
             (eq this-command #'corfu-doc-manually))
-    (if (and (frame-live-p corfu-doc--frame)
-             (frame-visible-p corfu-doc--frame))
-        (make-frame-invisible corfu-doc--frame))
+    (when (and (frame-live-p corfu-doc--frame)
+               (frame-visible-p corfu-doc--frame)
+               (not (eq (and (> corfu--total 0)
+                             (nth corfu--index corfu--candidates))
+                        corfu-doc--candidate)))
+      (make-frame-invisible corfu-doc--frame))
     (setq corfu-doc--timer
           (run-with-idle-timer
            corfu-doc-delay

--- a/corfu-doc.el
+++ b/corfu-doc.el
@@ -331,12 +331,12 @@ If this is nil, do not resize corfu doc frame automatically."
 (defun corfu-doc--set-timer (&rest _args)
   (when (or (null corfu-doc--timer)
             (eq this-command #'corfu-doc-manually))
+    (if (and (frame-live-p corfu-doc--frame)
+             (frame-visible-p corfu-doc--frame))
+        (make-frame-invisible corfu-doc--frame))
     (setq corfu-doc--timer
-          (run-with-timer
-           (if (and (frame-live-p corfu-doc--frame)
-                    (frame-visible-p corfu-doc--frame))
-               0
-             corfu-doc-delay)
+          (run-with-idle-timer
+           corfu-doc-delay
            nil #'corfu-doc-show))))
 
 (defun corfu-doc--cancel-timer ()


### PR DESCRIPTION
Updating doc frame immediately makes Emacs slow, specially when browsing completion candidates.  I changed `corfu-doc--set-timer` to hide doc frame when visible, then update using a **idle** timer instead of a ordinary timer.