### PR TITLE
Obsolete this package

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,7 +1,8 @@
 #+TITLE: corfu-doc - Documentation popup for Corfu
 #+AUTHOR: Yuwei Tian
 
-#+html: <a href="https://melpa.org/#/corfu-doc"><img alt="MELPA" src="https://melpa.org/packages/corfu-doc-badge.svg"/></a>
+*Important:* this package has been merged into Corfu as one of its [[https://github.com/minad/corfu#extensions][extensions]].
+And this repository is *deprecated* now.
 
 * Introduction
 

--- a/corfu-doc.el
+++ b/corfu-doc.el
@@ -478,6 +478,11 @@ The optional CANDIDATE-INDEX is the the current completion candidate index."
   "Corfu doc minor mode."
   :global t
   :group 'corfu
+  (display-warning
+   'corfu-doc
+   "This package is now obsolete and superseded by the corfu built-in extension. \
+Please try to migrate."
+   :warning)
   (cond
     (corfu-doc-mode
      (corfu-doc--manual-popup-show)


### PR DESCRIPTION
Since this package has been merged into corfu as one of its extensions. The `corfu-doc` package is now obsolete. See #16 and the [discussion] (https://github.com/galeo/corfu-doc/issues/16#issuecomment-1319421873).

Then I'll follow @minad's advice, wait another three months, archive this repository and remove it from MELPA.

@minad @AkibAzmain Do you think this is OK or enough?

